### PR TITLE
feat(code-review): optimize cost and improve review quality

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,38 +16,49 @@ on:
           REPO: ${{ github.repository }}
           PR NUMBER: ${{ github.event.pull_request.number }}
 
-          Perform a comprehensive code review with the following focus areas:
+          ## Instructions
 
-          1. **Code Quality**
-             - Clean code principles and best practices
-             - Proper error handling and edge cases
-             - Code readability and maintainability
+          1. **Read Project Guidelines First**
+             Check if the directory `${{ inputs.guidelines_dir }}` exists.
+             If it does, read ALL `.md` files in that directory - these contain the project's specific standards.
+             Prioritize these guidelines over generic advice.
 
-          2. **Security**
-             - Check for potential security vulnerabilities
-             - Validate input sanitization
-             - Review authentication/authorization logic
+          2. **Understand PR Scope**
+             - Read the PR title and description to understand the intent
+             - ONLY review changes within the stated scope
+             - Do NOT suggest refactoring or improvements outside the PR's purpose
+             - If you see issues that should be separate PRs, note them briefly at the end
 
-          3. **Performance**
-             - Identify potential performance bottlenecks
-             - Review database queries for efficiency
-             - Check for memory leaks or resource issues
+          3. **Review Output Format - IMPORTANT**
+             Create ONE single comment with your complete review using this structure:
 
-          4. **Testing**
-             - Verify adequate test coverage
-             - Review test quality and edge cases
-             - Check for missing test scenarios
+             ## Code Review Summary
 
-          5. **Documentation**
-             - Ensure code is properly documented
-             - Verify README updates for new features
-             - Check API documentation accuracy
-          
-          6. **Learning**
-            - Based on the code review, provide a list of learning points for the developer based on the book "The Pragmatic Programmer".
+             ### Critical Issues (if any)
+             - **[filename:line]** Description of issue
 
-          Provide detailed feedback using inline comments for specific issues.
-          Use top-level comments for general observations or praise.
+             ### Suggestions
+             - **[filename:line]** Suggestion
+
+             ### Out of Scope (brief notes only)
+             - Items that should be addressed in separate PRs
+
+             ### What Looks Good
+             - Brief positive notes
+
+             Do NOT create multiple inline comments. Put everything in ONE comment.
+
+          4. **Focus Areas** (priority order)
+             - Security vulnerabilities
+             - Bugs and logic errors
+             - Performance issues on critical paths
+             - Maintainability concerns
+
+          5. **Skip These**
+             - Lock files (package-lock.json, yarn.lock, etc.)
+             - Minified files (*.min.js, *.min.css)
+             - Generated files
+             - Stylistic nitpicks (unless they violate project guidelines)
       use_sticky_comment:
         description: 'Use sticky comments to reuse the same comment on subsequent pushes'
         required: false
@@ -73,6 +84,11 @@ on:
         description: 'Condition to skip review (e.g., contains title WIP)'
         required: false
         type: string
+      guidelines_dir:
+        description: 'Directory containing review guidelines (.md files). Claude reads all markdown files in this directory.'
+        required: false
+        type: string
+        default: 'docs/code-review'
     secrets:
       ANTHROPIC_API_KEY:
         description: 'Anthropic API key for Claude Code'
@@ -129,4 +145,4 @@ jobs:
           # DISABLED: See comment above in inputs section for details
           claude_args: |
             --model ${{ inputs.model || 'claude-sonnet-4-5-20250929' }}
-            --allowed-tools "${{ steps.sanitize.outputs.allowed_tools != '' && steps.sanitize.outputs.allowed_tools || 'mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)' }}"
+            --allowed-tools "${{ steps.sanitize.outputs.allowed_tools != '' && steps.sanitize.outputs.allowed_tools || 'Read,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)' }}"

--- a/automated-code-review/templates/review-guidelines.md
+++ b/automated-code-review/templates/review-guidelines.md
@@ -1,5 +1,7 @@
 # Code Review Guidelines
 
+> **Note:** Claude reads all `.md` files in `docs/code-review/` before reviewing PRs. You can split guidelines into multiple files (e.g., `security.md`, `style.md`, `api.md`).
+
 These guidelines are used by Claude to align feedback with project expectations.
 
 ## Focus areas
@@ -16,3 +18,11 @@ These guidelines are used by Claude to align feedback with project expectations.
 - Prefer suggestions over rewrites
 - Call out risks clearly
 - Avoid stylistic nitpicking unless it affects clarity or safety
+
+## Project-specific rules (customize these)
+
+<!-- Add your project-specific rules below. Examples: -->
+<!-- - All API endpoints must have authentication middleware -->
+<!-- - Use TypeScript strict mode - no `any` types -->
+<!-- - Database migrations must be reversible -->
+<!-- - Feature flags required for new user-facing features -->

--- a/automated-code-review/workflow.yml
+++ b/automated-code-review/workflow.yml
@@ -17,6 +17,9 @@ jobs:
       id-token: write
     
     uses: ColoredCow/engineering-recipes/.github/workflows/claude-code-review.yml@main
-    
+
+    with:
+      guidelines_dir: 'docs/code-review'
+
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- **Cost optimization**: Single consolidated comment instead of multiple inline comments (~50% cost reduction)
- **Project-specific guidelines**: Claude reads all `.md` files from `docs/code-review/` directory
- **Scope awareness**: Reviews only what's within the PR's stated intent
- **Streamlined prompt**: Prioritized focus areas, skip list for generated files

## Problem

| Issue | Impact |
|-------|--------|
| $50 credits exhausted in 2 days | Projected $1000/month vs $400 target |
| Single PR review costs $0.89 | Too expensive |
| Multiple scattered comments | Cluttered PR threads |
| Generic feedback | Not aligned with project standards |
| Reviews out-of-scope items | Wastes developer time |

## Changes

### 1. Single Comment Output
- Removed `mcp__github_inline_comment__create_inline_comment` from allowed tools
- Added explicit instruction for ONE summary comment with structured format

### 2. Project Guidelines Support
- New `guidelines_dir` input (default: `docs/code-review`)
- Claude reads ALL `.md` files in the directory
- Projects can split guidelines: `security.md`, `style.md`, `api.md`, etc.

### 3. Scope Awareness
- Explicit instruction to read PR title/description for intent
- Only review changes within stated scope
- Out-of-scope items noted briefly, not reviewed

### 4. Prompt Optimization
- Removed generic "Learning" section
- Prioritized focus: Security → Bugs → Performance → Maintainability
- Skip list: lock files, minified files, generated files

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| Cost per review | $0.89 | ~$0.40 |
| Monthly projected | $1000 | ~$400 |
| Comments per review | Multiple | ONE |
| Guidelines support | None | Directory-based |

## Test plan

- [ ] Create test PR in a project using this workflow
- [ ] Add "ready for review" label
- [ ] Verify Claude creates ONE comment (not multiple)
- [ ] Verify Claude reads guidelines if `docs/code-review/` exists
- [ ] Verify review stays within PR scope
- [ ] Monitor API cost in Anthropic dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)