### PR TITLE
feat: limit automated code review to max 2 runs per PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -129,8 +129,47 @@ jobs:
           sanitized_tools="${sanitized_tools//\`/\\\`}"
           echo "allowed_tools=${sanitized_tools}" >> $GITHUB_OUTPUT
 
+      - name: Check review run limit
+        id: run-limit
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BYPASS=$(gh pr view "$PR_NUMBER" --json labels \
+            --jq '[.labels[].name] | contains(["claude-review-bypass"])')
+
+          if [ "$BYPASS" = "true" ]; then
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Bypass label present. Skipping run limit."
+            exit 0
+          fi
+
+          COUNT=$(gh pr view "$PR_NUMBER" --json labels \
+            --jq '[.labels[].name | select(startswith("claude-review-run-"))] | length')
+
+          echo "Review runs so far: $COUNT"
+
+          if [ "$COUNT" -ge 2 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "Max review limit (2) reached for PR #$PR_NUMBER. Skipping."
+          else
+            NEXT=$((COUNT + 1))
+            gh label create "claude-review-run-$NEXT" --color "d4c5f9" \
+              --description "Claude Code Review run $NEXT" --force 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label "claude-review-run-$NEXT"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            echo "Starting review run $NEXT for PR #$PR_NUMBER."
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
       - name: Run Claude Code Review
         id: claude-review
+        if: steps.run-limit.outputs.skip != 'true'
         uses: anthropics/claude-code-action@v1.0.8
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a `Check review run limit` step before Claude runs
- Tracks run count via PR labels (`claude-review-run-1`, `claude-review-run-2`)
- Skips review once 2 runs are completed for a PR
- Add `claude-review-bypass` label to any PR to skip the limit

## Test plan
- [ ] Open a PR — verify `claude-review-run-1` label added, review runs
- [ ] Push a commit to same PR — verify `claude-review-run-2` label added, review runs
- [ ] Push again — verify review is skipped
- [ ] Add `claude-review-bypass` label — verify review runs regardless of count

🤖 Generated with [Claude Code](https://claude.com/claude-code)